### PR TITLE
Function bodies deferred error reporting

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -61,6 +61,14 @@ Support for explicit tail calls is planned in
 which would add an explicit tail-call operator with well-defined effects
 on stack introspection.
 
+## Invalid AST Reporting
+
+An invalid AST can occur during compilation if there is an unknown or malformed
+construct in the source or if the implementor doesn't support a feature.
+
+This results in a [trap](#traps) that is reported once the function with the
+error is called.
+
 ## Types
 
 WebAssembly has the following *value types*:


### PR DESCRIPTION
## Proposal

This is a proposal to change the moment where we report an error during decoding of a function.
At this time, any malformed or not yet implemented feature in WebAssembly renders the module invalid.
This forces to parse and validate the full extent of the module.

This proposition would allow implementors to decide when is a good time to read the content of the function to generate code.
The implementor is still free to parse and validate the whole module ahead of time, but should only report any errors found when the function is called.
## Reasoning

First of all, at Microsoft, we believe that since most if not all WebAssembly module will be generated by tools, it should be fair to assume the module is well formed and valid until proved otherwise.
This means, we could ignore the functions that are not called during initialization of the module and save time and memory.
Thus, the main goal is to increase performance of WebAssembly and give flexibility on the implementation.

Using AngryBots as a reference, 
We measured that <25% of the functions in the module are called during the first minute of game play.
These functions represents ~26% of the size of all code in the module (3 169 049 / 12 164 730 bytes).
This means, about 75% of the functions in the module doesn't need to even be looked at for a long time which translate to precious cpu time saved and memory.

I implemented a prototype to parse and generate bytecode of the function on the first call.
With this, I went from ~500ms spent parsing and generating bytecode to ~150ms, about 70% cpu time gain.
I also looked at jit time and it goes from ~32sec to ~7sec to prejit the whole module and only the startup functions respectively. (This is with single thread jit).
The jit time is not as interesting to look at from our perspective, because we already delay the moment we jit the function with the current design.

However, the gain of ~350ms for parsing and bytecode is not negligible considering that AngryBots is still a fairly small game, this change could translate to wins in seconds of performance for us.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cellule/design/1)

<!-- Reviewable:end -->
